### PR TITLE
feat: add force push bypasser support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -208,6 +208,7 @@ resource "github_branch_protection" "branch_protection" {
 
   allows_deletions                = try(var.branch_protections_v4[each.value].allows_deletions, false)
   allows_force_pushes             = try(var.branch_protections_v4[each.value].allows_force_pushes, false)
+  force_push_bypassers            = try(var.branch_protections_v4[each.value].force_push_bypassers, [])
   blocks_creations                = try(var.branch_protections_v4[each.value].blocks_creations, false)
   enforce_admins                  = try(var.branch_protections_v4[each.value].enforce_admins, true)
   push_restrictions               = try(var.branch_protections_v4[each.value].push_restrictions, [])

--- a/versions.tf
+++ b/versions.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = ">= 4.20, < 6.0"
+      version = ">= 5.27, < 6.0"
     }
   }
 }


### PR DESCRIPTION
## Putting up a PR against my own repo for now, not sure if it's worth the time digging into this further when we have a temporary fix, especially since the source module from Minerios isn't being maintained

Since v5.27 of the GitHub provider (https://github.com/integrations/terraform-provider-github/releases/tag/v5.27.0) they allowed `force_push_bypassers`.

Normally I guess I'd make this PR to the source repo but seems like they're not maintaining it anymore & we're using this, so I'm adding this here too.

See this Slack thread for reference: https://masterpoint.slack.com/archives/C035S6TE7PC/p1718145737763459?thread_ts=1718145385.157139&cid=C035S6TE7PC

The branch protection was missing force push rule (which we want to bypass for our GitOps bot). So as a workaround, rulesets were used. And it led to issues with overlap mentioned in the Slack thread. 

I'm hoping to roll this out so we can have everything that we needed a ruleset for into the branch protection, so we can get rid of the ruleset and use just  branch protections.

I tested this with a plan and it's clean - there's no affected changes with this version. 